### PR TITLE
ParseReader(io.Reader) and Template.RenderTo(io.Writer, ...interface{}). Custom partials.

### DIFF
--- a/tests/test3.mustache
+++ b/tests/test3.mustache
@@ -1,3 +1,3 @@
 {{#users}}
-{{> partial}}
+{{> codepart}}
 {{/users}}

--- a/tests/test4.mustache
+++ b/tests/test4.mustache
@@ -1,0 +1,8 @@
+<li>
+	{{contents}}
+	<ul>
+		{{#children}}
+			{{> node}}
+		{{/children}}
+	</ul>
+</li>


### PR DESCRIPTION
I added the ability to parse data from an io.Reader, and the ability to render to an io.Writer.

I also added the ability to set up custom partials before parsing. Using custom partials require some slightly reworked code. See the changes to TestSectionPartial() and TestRecursivePartial() in mustache_test.go to see how it works.
