### PR TITLE
Conform to spec: empty list evaluates inverted section

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -428,6 +428,51 @@ func isNil(v reflect.Value) bool {
     switch val := valueInd; val.Kind() {
     case reflect.Bool:
         return !val.Bool()
+
+    case reflect.Int:
+        fallthrough
+    case reflect.Int8:
+        fallthrough
+    case reflect.Int16:
+        fallthrough
+    case reflect.Int32:
+        fallthrough
+    case reflect.Int64:
+        return val.Int() == 0
+
+    case reflect.Uint:
+        fallthrough
+    case reflect.Uintptr:
+        fallthrough
+    case reflect.Uint8:
+        fallthrough
+    case reflect.Uint16:
+        fallthrough
+    case reflect.Uint32:
+        fallthrough
+    case reflect.Uint64:
+        return val.Uint() == 0
+
+    case reflect.Float32:
+        fallthrough
+    case reflect.Float64:
+        return val.Float() == 0
+
+    case reflect.Array:
+        fallthrough
+    case reflect.Chan:
+        fallthrough
+    case reflect.Map:
+        fallthrough
+    case reflect.Slice:
+        fallthrough
+    case reflect.String:
+        return val.Len() == 0
+
+    case reflect.Complex64:
+        fallthrough
+    case reflect.Complex128:
+        return val.Complex() == complex(0, 0)
     }
 
     return false
@@ -454,9 +499,12 @@ func renderSection(section *sectionElement, contextChain []interface{}, buf io.W
     var contexts = []interface{}{}
     // if the value is nil, check if it's an inverted section
     isNil := isNil(value)
-    if isNil && !section.inverted || !isNil && section.inverted {
-        return
-    } else {
+
+    if isNil && section.inverted {
+        val := indirect(value)
+        contexts = append(contexts, val)
+
+    } else if !isNil && !section.inverted {
         valueInd := indirect(value)
         switch val := valueInd; val.Kind() {
         case reflect.Slice:
@@ -472,6 +520,8 @@ func renderSection(section *sectionElement, contextChain []interface{}, buf io.W
         default:
             contexts = append(contexts, context)
         }
+    } else {
+        return
     }
 
     chain2 := make([]interface{}, len(contextChain)+1)

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -132,6 +132,10 @@ var tests = []Test{
     {`{{^a}}b{{/a}}`, map[string]interface{}{"a": false}, "b"},
     {`{{^a}}b{{/a}}`, map[string]interface{}{"a": true}, ""},
     {`{{^a}}b{{/a}}`, map[string]interface{}{"a": "nonempty string"}, ""},
+    {`{{^a}}falseint{{/a}}`, map[string]interface{}{"a": 0}, "falseint"},
+    {`{{^a}}falsereal{{/a}}`, map[string]interface{}{"a": 0.0}, "falsereal"},
+    {`{{^a}}falselist{{/a}}`, map[string]interface{}{"a": []string{}}, "falselist"},
+    {`{{^a}}falseplist{{/a}}`, map[string]interface{}{"a": []*string{}}, "falseplist"},
 
     //function tests
     {`{{#users}}{{Func1}}{{/users}}`, map[string]interface{}{"users": []User{{"Mike", 1}}}, "Mike"},


### PR DESCRIPTION
The mustache manual[1] states the following:

```
While sections can be used to render text one or more times based on the
value of the key, inverted sections may render text once based on the
inverse value of the key. That is, they will be rendered if the key
doesn't exist, is false, or is an empty list.
```

The previous implementation, upon encountering an empty list, iterated
over the items in the list and rendered each one. Since the list was
empty, nothing would be emitted for an inverted section over an empty
list, thus the following template would never have any output:

```
{{#list}} not empty {{/list}}
{{^list}} empty {{/list}}
```

Furthermore, though the mustache spec isn't clear on what constitutes a
`false` value, I felt that the definition in `isNil` was too
constrained -- most primitive zero-values were not handled and defined
as non-false. This, unfortunately, included common things like integers,
maps, lists, etc. I have amended `isNil` to switch on every
`reflect.Kind` and check for zero-value equivalents (e.g., empty
lists/maps/channels/strings, 0-value numerics).

Finally, tests have been added for these additions.

[1] http://mustache.github.com/mustache.5.html
