### PR TITLE
Add more informative error message when partial is not found.

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -140,7 +140,8 @@ func (tmpl *Template) parsePartial(name string) (*Template, error) {
         }
     }
     if filename == "" {
-        return nil, errors.New(fmt.Sprintf("Could not find partial %q", name))
+        return nil, errors.New(fmt.Sprintf("Could not find partial %q in %q",
+            name, filenames))
     }
 
     partial, err := ParseFile(filename)
@@ -390,7 +391,7 @@ Outer:
                 }
             }
             if name == "." {
-              return v
+                return v
             }
             switch av := v; av.Kind() {
             case reflect.Ptr:


### PR DESCRIPTION
Makes it easier to fix problems when you know specifically what went wrong.  In this case, you'll now get an error message similar to the following:

```
Could not find partial "navbar" in ["templ/navbar" "templ/navbar.mustache" "templ/navbar.stache" "navbar" "navbar.mustache" "navbar.stache"]
```
