### PR TITLE
Use html escaper function from html/template

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -4,6 +4,7 @@ import (
     "bytes"
     "errors"
     "fmt"
+    "html/template"
     "io"
     "io/ioutil"
     "os"
@@ -52,32 +53,6 @@ var (
     esc_lt   = []byte("&lt;")
     esc_gt   = []byte("&gt;")
 )
-
-// taken from pkg/template
-func htmlEscape(w io.Writer, s []byte) {
-    var esc []byte
-    last := 0
-    for i, c := range s {
-        switch c {
-        case '"':
-            esc = esc_quot
-        case '\'':
-            esc = esc_apos
-        case '&':
-            esc = esc_amp
-        case '<':
-            esc = esc_lt
-        case '>':
-            esc = esc_gt
-        default:
-            continue
-        }
-        w.Write(s[last:i])
-        w.Write(esc)
-        last = i + 1
-    }
-    w.Write(s[last:])
-}
 
 func (tmpl *Template) readString(s string) (string, error) {
     i := tmpl.p
@@ -390,7 +365,7 @@ Outer:
                 }
             }
             if name == "." {
-              return v
+                return v
             }
             switch av := v; av.Kind() {
             case reflect.Ptr:
@@ -509,7 +484,7 @@ func renderElement(element interface{}, contextChain []interface{}, buf io.Write
                 fmt.Fprint(buf, val.Interface())
             } else {
                 s := fmt.Sprint(val.Interface())
-                htmlEscape(buf, []byte(s))
+                template.HTMLEscape(buf, []byte(s))
             }
         }
     case *sectionElement:


### PR DESCRIPTION
Instead of using a copy/pasted old html escaper, use the latest HTML escaper from `html/template`. This makes output more dependant on your version of the Go core libraries, but also increases security.
