### PR TITLE
Add dot notation support

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -369,6 +369,14 @@ func call(v reflect.Value, method reflect.Method) reflect.Value {
 // Evaluate interfaces and pointers looking for a value that can look up the name, via a
 // struct field, method, or map key, and return the result of the lookup.
 func lookup(contextChain []interface{}, name string) reflect.Value {
+    // dot notation
+    if name != "." && strings.Contains(name, ".") {
+        parts := strings.SplitN(name, ".", 2)
+        
+        v := lookup(contextChain, parts[0])
+        return lookup([]interface{}{v}, parts[1])
+    }
+
     defer func() {
         if r := recover(); r != nil {
             fmt.Printf("Panic while looking up %q: %s\n", name, r)

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -164,6 +164,15 @@ var tests = []Test{
 
     //invalid syntax - https://github.com/hoisie/mustache/issues/10
     {`{{#a}}{{#b}}{{/a}}{{/b}}}`, map[string]interface{}{}, "line 1: interleaved closing tag: a"},
+
+    //dotted names(dot notation)
+    {`"{{person.name}}" == "{{#person}}{{name}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`},
+    {`"{{{person.name}}}" == "{{#person}}{{{name}}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`},
+    {`"{{a.b.c.d.e.name}}" == "Phil"`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": map[string]interface{}{"d": map[string]interface{}{"e": map[string]string{"name": "Phil"}}}}}}, `"Phil" == "Phil"`},
+    {`"{{a.b.c}}" == ""`, map[string]interface{}{}, `"" == ""`},
+    {`"{{a.b.c.name}}" == ""`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]string{}}, "c": map[string]string{"name": "Jim"}}, `"" == ""`},
+    {`"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": map[string]interface{}{"d": map[string]interface{}{"e": map[string]string{"name": "Phil"}}}}}, "b": map[string]interface{}{"c": map[string]interface{}{"d": map[string]interface{}{"e": map[string]string{"name": "Wrong"}}}}}, `"Phil" == "Phil"`},
+    {`{{#a}}{{b.c}}{{/a}}`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]string{}}, "b": map[string]string{"c": "ERROR"}}, ""},
 }
 
 func TestBasic(t *testing.T) {


### PR DESCRIPTION
According to the [Mustache spec](https://github.com/mustache/spec), the dot notation should be available. 

```
Hello {{person.name}}
```

Other Mustache implements such as [mustache.js](https://github.com/janl/mustache.js) have already done the job.

I've achieved the feature in the `lookup` function, and added some [tests from the spec](https://github.com/mustache/spec/blob/master/specs/interpolation.yml#L124)
