### PR TITLE
Use Getwd(), support direct customization of the 'cwd' path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 ## Overview
 
-mustache.go is an implementation of the mustache template language in Go. It is better suited for website templates than Go's native pkg/template. mustache.go is fast -- it parses templates efficiently and stores them in a tree-like structure which allows for fast execution. 
+mustache.go is an implementation of the mustache template language in Go. It is better suited for website templates than Go's native pkg/template. mustache.go is fast -- it parses templates efficiently and stores them in a tree-like structure which allows for fast execution.
 
 ## Documentation
 
@@ -21,12 +21,14 @@ func RenderFile(filename string, context ...interface{}) string
 
 func ParseString(data string) (*Template, os.Error)
 
+func ParseStringInDir(data string, dir string) (*Template, os.Error)
+
 func ParseFile(filename string) (*Template, os.Error)
 ```
 
 There are also two additional methods for using layouts (explained below).
 
-The Render method takes a string and a data source, which is generally a map or struct, and returns the output string. If the template file contains an error, the return value is a description of the error. There's a similar method, RenderFile, which takes a filename as an argument and uses that for the template contents. 
+The `Render` method takes a string and a data source, which is generally a map or struct, and returns the output string. If the template file contains an error, the return value is a description of the error. There's a similar method, `RenderFile`, which takes a filename as an argument and uses that for the template contents.
 
 ```go
 data := mustache.Render("hello {{c}}", map[string]string{"c":"world"})
@@ -39,7 +41,7 @@ If you're planning to render the same template multiple times, you do it efficie
 tmpl,_ := mustache.ParseString("hello {{c}}")
 var buf bytes.Buffer;
 for i := 0; i < 10; i++ {
-    tmpl.Render (map[string]string { "c":"world"}, &buf)  
+    tmpl.Render(map[string]string{"c":"world"}, &buf)
 }
 ```
 
@@ -58,7 +60,7 @@ func RenderInLayout(data string, layout string, context ...interface{}) string
 
 func RenderFileInLayout(filename string, layoutFile string, context ...interface{}) string
 ```
-    
+
 The layout file must have a variable called `{{content}}`. For example, given the following files:
 
 layout.html.mustache:
@@ -96,7 +98,7 @@ Mustache.go supports calling methods on objects, but you have to be aware of Go'
 ```go
 type Person struct {
     FirstName string
-    LastName string    
+    LastName string
 }
 
 func (p *Person) Name1() string {

--- a/mustache.go
+++ b/mustache.go
@@ -347,7 +347,7 @@ func lookup(contextChain []interface{}, name string) reflect.Value {
     // dot notation
     if name != "." && strings.Contains(name, ".") {
         parts := strings.SplitN(name, ".", 2)
-        
+
         v := lookup(contextChain, parts[0])
         return lookup([]interface{}{v}, parts[1])
     }
@@ -528,8 +528,15 @@ func (tmpl *Template) RenderInLayout(layout *Template, context ...interface{}) s
 }
 
 func ParseString(data string) (*Template, error) {
-    cwd := os.Getenv("CWD")
-    tmpl := Template{data, "{{", "}}", 0, 1, cwd, []interface{}{}}
+    cwd, err := os.Getwd()
+    if err != nil {
+        return nil, err
+    }
+    return ParseStringInDir(data, cwd)
+}
+
+func ParseStringInDir(data string, dir string) (*Template, error) {
+    tmpl := Template{data, "{{", "}}", 0, 1, dir, []interface{}{}}
     err := tmpl.parse()
 
     if err != nil {
@@ -547,14 +554,7 @@ func ParseFile(filename string) (*Template, error) {
 
     dirname, _ := path.Split(filename)
 
-    tmpl := Template{string(data), "{{", "}}", 0, 1, dirname, []interface{}{}}
-    err = tmpl.parse()
-
-    if err != nil {
-        return nil, err
-    }
-
-    return &tmpl, nil
+    return ParseStringInDir(string(data), dirname)
 }
 
 func Render(data string, context ...interface{}) string {

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -185,7 +185,11 @@ func TestBasic(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
-    filename := path.Join(path.Join(os.Getenv("PWD"), "tests"), "test1.mustache")
+    cwd, err := os.Getwd()
+    if err != nil {
+        t.Fatalf("couldn't get working directory: %s", err)
+    }
+    filename := path.Join(cwd, "tests", "test1.mustache")
     expected := "hello world"
     output := RenderFile(filename, map[string]string{"name": "world"})
     if output != expected {
@@ -194,7 +198,11 @@ func TestFile(t *testing.T) {
 }
 
 func TestPartial(t *testing.T) {
-    filename := path.Join(path.Join(os.Getenv("PWD"), "tests"), "test2.mustache")
+    cwd, err := os.Getwd()
+    if err != nil {
+        t.Fatalf("couldn't get working directory: %s", err)
+    }
+    filename := path.Join(cwd, "tests", "test2.mustache")
     println(filename)
     expected := "hello world"
     output := RenderFile(filename, map[string]string{"Name": "world"})
@@ -203,9 +211,12 @@ func TestPartial(t *testing.T) {
     }
 }
 
-/*
 func TestSectionPartial(t *testing.T) {
-    filename := path.Join(path.Join(os.Getenv("PWD"), "tests"), "test3.mustache")
+    cwd, err := os.Getwd()
+    if err != nil {
+        t.Fatalf("couldn't get working directory: %s", err)
+    }
+    filename := path.Join(cwd, "tests", "test3.mustache")
     expected := "Mike\nJoe\n"
     context := map[string]interface{}{"users": []User{{"Mike", 1}, {"Joe", 2}}}
     output := RenderFile(filename, context)
@@ -213,7 +224,7 @@ func TestSectionPartial(t *testing.T) {
         t.Fatalf("testSectionPartial expected %q got %q", expected, output)
     }
 }
-*/
+
 func TestMultiContext(t *testing.T) {
     output := Render(`{{hello}} {{World}}`, map[string]string{"hello": "hello"}, struct{ World string }{"world"})
     output2 := Render(`{{hello}} {{World}}`, struct{ World string }{"world"}, map[string]string{"hello": "hello"})


### PR DESCRIPTION
- Not seeing a `CWD` envvar as of Ubuntu Linux 16.04. Probably meant `PWD`? May as well use the standard `Getwd()` for this.
- It'd also be useful to support explicitly providing that 'cwd' value via the API. Adds a new `ParseStringInDir()` function to support this. It came up for me when I was trying to pass the string contents of a file, where I wanted to have both old and new versions of the content to show in a diff. Example:
    
```
oldData, _ := ioutil.ReadFile(path)
template, _ := mustache.ParseStringInPath(string(oldData), dir)
newData := template.Render(map)
// ... show diff of oldData vs newData ...
```
- Finally, reenables a commented-out test which seems to be passing just fine...
